### PR TITLE
[JENKINS-50271] - Stop serializing logger to the disk in CukedoctorPublisher

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,2 @@
+// Build the plugin using https://github.com/jenkins-infra/pipeline-library
+buildPlugin(jenkinsVersions: [null, "2.107.1"])

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
         <jenkins.version>2.73.3</jenkins.version>
-        <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
-        <java.level>7</java.level>
+        <!-- Java Level to use. Java 8 required when using core >= 2.50 -->
+        <java.level>8</java.level>
     </properties>
 
     <name>Cucumber Living Documentation Plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.2</version>
+        <version>3.5</version>
         <relativePath />
     </parent>
     <artifactId>cucumber-living-documentation</artifactId>
@@ -14,7 +14,7 @@
 
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.73.1</jenkins.version>
+        <jenkins.version>2.73.3</jenkins.version>
         <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
         <java.level>7</java.level>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.5</version>
+        <version>3.6</version>
         <relativePath />
     </parent>
     <artifactId>cucumber-living-documentation</artifactId>
@@ -21,7 +21,7 @@
 
     <name>Cucumber Living Documentation Plugin</name>
     <description>Enables Cucumber living documentation on Jenkins</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Cucumber+Living+Documentation+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Cucumber+Living+Documentation+Plugin</url>
 
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
 
@@ -115,12 +115,6 @@
             <artifactId>workflow-cps</artifactId>
             <version>2.13</version>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/src/main/java/com/github/cukedoctor/jenkins/CukedoctorPublisher.java
+++ b/src/main/java/com/github/cukedoctor/jenkins/CukedoctorPublisher.java
@@ -92,9 +92,6 @@ public class CukedoctorPublisher extends Recorder implements SimpleBuildStep {
 
     private boolean hideTags;
 
-    private PrintStream logger;
-
-
     @DataBoundConstructor
     public CukedoctorPublisher(String featuresDir, FormatType format, TocType toc, Boolean numbered, Boolean sectAnchors, String title, boolean hideFeaturesSection, boolean hideSummary,
                                boolean hideScenarioKeyword, boolean hideStepTime, boolean hideTags) {
@@ -134,7 +131,7 @@ public class CukedoctorPublisher extends Recorder implements SimpleBuildStep {
             workspaceJsonSourceDir = new FilePath(workspace, featuresDir);
         }
 
-        logger = listener.getLogger();
+        PrintStream logger = listener.getLogger();
 
         logger.println("");
         logger.println("Generating living documentation for " + build.getFullDisplayName() + " with the following arguments: ");


### PR DESCRIPTION
This change makes the plugin compatible with 2.102+ (at least according to the tests). The plugin still produces warnings for improper nested references due to `CukedoctorBuildAction` bundling `CukedoctorProjectAction` with project reference, but I decided to not touch it for now (better to fix the breaking issue first).

https://issues.jenkins-ci.org/browse/JENKINS-50271

@reviewbybees @jglick @rmpestano 